### PR TITLE
Fathom Analytics

### DIFF
--- a/_pages/legal.md
+++ b/_pages/legal.md
@@ -110,6 +110,7 @@ The HydePHP logo is based on the following graphics from the Twitter Twemoji pro
 ### Sponsorships and affiliates
 
 - Thank you to [UptimeRobot](https://uptimerobot.com/?rid=33f574d058c2f3) for sponsoring the [HydePHP Status Monitor](https://status.hydephp.com/) page!
+- Thank you to [Fathom Analytics](https://usefathom.com/) for sponsoring HydePHP with privacy-focused analytics!
 
 Want to sponsor the HydePHP project? Send us an email at hello@hydephp.com!<br>
 You can also ping the creator on Twitter at [@CodeWithCaen](https://twitter.com/CodeWithCaen){:rel="noopener"}

--- a/_pages/legal.md
+++ b/_pages/legal.md
@@ -110,7 +110,7 @@ The HydePHP logo is based on the following graphics from the Twitter Twemoji pro
 ### Sponsorships and affiliates
 
 - Thank you to [UptimeRobot](https://uptimerobot.com/?rid=33f574d058c2f3) for sponsoring the [HydePHP Status Monitor](https://status.hydephp.com/) page!
-- Thank you to [Fathom Analytics](https://usefathom.com/) for sponsoring HydePHP with privacy-focused analytics!
+- Thank you to [Fathom Analytics](https://usefathom.com/) for sponsoring HydePHP with privacy-focused analytics! Our analytics dashboard is [publicly available](https://app.usefathom.com/share/tbqmayhy/hydephp.com).
 
 Want to sponsor the HydePHP project? Send us an email at hello@hydephp.com!<br>
 You can also ping the creator on Twitter at [@CodeWithCaen](https://twitter.com/CodeWithCaen){:rel="noopener"}

--- a/_pages/legal.md
+++ b/_pages/legal.md
@@ -112,6 +112,7 @@ The HydePHP logo is based on the following graphics from the Twitter Twemoji pro
 - Thank you to [UptimeRobot](https://uptimerobot.com/?rid=33f574d058c2f3) for sponsoring the [HydePHP Status Monitor](https://status.hydephp.com/) page!
 - Thank you to [Fathom Analytics](https://usefathom.com/) for sponsoring HydePHP with privacy-focused analytics!
   - Our analytics dashboard is [publicly available](https://app.usefathom.com/share/tbqmayhy/hydephp.com).
+  - You can get a $10 discount by using our [affiliate link](https://usefathom.com/ref/NMDUJJ).
 
 Want to sponsor the HydePHP project? Send us an email at hello@hydephp.com!<br>
 You can also ping the creator on Twitter at [@CodeWithCaen](https://twitter.com/CodeWithCaen){:rel="noopener"}

--- a/_pages/legal.md
+++ b/_pages/legal.md
@@ -110,7 +110,8 @@ The HydePHP logo is based on the following graphics from the Twitter Twemoji pro
 ### Sponsorships and affiliates
 
 - Thank you to [UptimeRobot](https://uptimerobot.com/?rid=33f574d058c2f3) for sponsoring the [HydePHP Status Monitor](https://status.hydephp.com/) page!
-- Thank you to [Fathom Analytics](https://usefathom.com/) for sponsoring HydePHP with privacy-focused analytics! Our analytics dashboard is [publicly available](https://app.usefathom.com/share/tbqmayhy/hydephp.com).
+- Thank you to [Fathom Analytics](https://usefathom.com/) for sponsoring HydePHP with privacy-focused analytics!
+  - Our analytics dashboard is [publicly available](https://app.usefathom.com/share/tbqmayhy/hydephp.com).
 
 Want to sponsor the HydePHP project? Send us an email at hello@hydephp.com!<br>
 You can also ping the creator on Twitter at [@CodeWithCaen](https://twitter.com/CodeWithCaen){:rel="noopener"}

--- a/resources/views/vendor/hyde/layouts/head.blade.php
+++ b/resources/views/vendor/hyde/layouts/head.blade.php
@@ -17,3 +17,7 @@
 <meta id="meta-color-scheme" name="color-scheme" content="{{ config('hyde.default_color_scheme', 'light') }}">
 <script>if (localStorage.getItem('color-theme') === 'dark' || (!('color-theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) { document.documentElement.classList.add('dark'); document.getElementById('meta-color-scheme').setAttribute('content', 'dark');} else { document.documentElement.classList.remove('dark') } </script>
 @endif
+
+<!-- Sponsored by Fathom - beautiful, simple website analytics -->
+<script src="https://cdn.usefathom.com/script.js" data-site="TBQMAYHY" defer></script>
+<!-- / Fathom -->


### PR DESCRIPTION
[Fathom Analytics](https://usefathom.com/) is graciously sponsoring HydePHP with their privacy-focused analytics. This PR sets up the integration, and adds a thank you note to the legal page. Our dashboard is visible at https://app.usefathom.com/share/tbqmayhy/hydephp.com.