### PR TITLE
Update pull request previews to use new deployment server

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Create dotenv
       run: |
         echo 'SITE_NAME="HydePHP.com PR Preview"' > .env
-        echo "SITE_URL=https://hydephp.github.io/previews/hydephp-com/${{ github.event.pull_request.number }}" >> .env
+        echo "SITE_URL=https://ci.hydephp.com/previews/website/${{ github.event.pull_request.number }}" >> .env
         echo "TORCHLIGHT_TOKEN=${{ secrets.TORCHLIGHT_TOKEN }}" >> .env
         echo "ROBOTS_NOINDEX=true" >> .env
 
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pull-request-preview
-      url: https://hydephp.github.io/previews/hydephp-com/${{ github.event.pull_request.number }}
+      url: https://ci.hydephp.com/previews/website/${{ github.event.pull_request.number }}
 
     steps:
       - name: Download the artifact
@@ -96,7 +96,7 @@ jobs:
           target-directory: "docs/hydephp-com/${{ github.event.pull_request.number }}"
 
       - name: Output the URL
-        run: echo "https://hydephp.github.io/previews/hydephp-com/${{ github.event.pull_request.number }}"
+        run: echo "https://ci.hydephp.com/previews/website/${{ github.event.pull_request.number }}"
 
 
   comment-on-pull-request:
@@ -113,5 +113,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'A [live preview](https://hydephp.github.io/previews/hydephp-com/${{ github.event.pull_request.number }}) is being deployed!<br><br>Please note that it may take a few seconds for GitHub Pages to build and deploy. The preview will be removed at midnight UTC.'
+              body: 'A [live preview](https://ci.hydephp.com/previews/website/${{ github.event.pull_request.number }}) is being deployed!<br><br>Please note that it may take a few seconds for GitHub Pages to build and deploy. The preview will be removed at midnight UTC.'
             })

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -103,6 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+
     # Only run if a comment was not already made
     if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' && !contains(github.event.pull_request.body, 'A [live preview]') }}
     steps:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         echo 'SITE_NAME="HydePHP.com PR Preview"' > .env
         echo "SITE_URL=https://ci.hydephp.com/previews/website/${{ github.event.pull_request.number }}" >> .env
-        echo "TORCHLIGHT_TOKEN=${{ secrets.TORCHLIGHT_TOKEN }}" >> .env
+        # echo "TORCHLIGHT_TOKEN=${{ secrets.TORCHLIGHT_TOKEN }}" >> .env
         echo "ROBOTS_NOINDEX=true" >> .env
 
     - name: Install composer dependencies

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -74,7 +74,7 @@ jobs:
 
     - name: Package the static site
       run: zip -r site.zip _site
-    
+
 
   comment-on-pull-request:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -13,9 +13,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '14'
+#    - uses: actions/setup-node@v2
+#      with:
+#        node-version: '14'
 
     - name: Validate composer.json and composer.lock
       run: composer validate
@@ -38,25 +38,25 @@ jobs:
 
     - name: Install composer dependencies
       run: composer install
-
-    - name: Cache node modules
-      uses: actions/cache@v3
-      env:
-        cache-name: cache-node-modules
-      with:
-        # npm cache files are stored in `~/.npm` on Linux/macOS
-        path: ~/.npm
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
-
-    - name: Install Node dependencies
-      run: npm install
-
-    - name: Build frontend assets
-      run: npm run prod
+#
+#    - name: Cache node modules
+#      uses: actions/cache@v3
+#      env:
+#        cache-name: cache-node-modules
+#      with:
+#        # npm cache files are stored in `~/.npm` on Linux/macOS
+#        path: ~/.npm
+#        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+#        restore-keys: |
+#          ${{ runner.os }}-build-${{ env.cache-name }}-
+#          ${{ runner.os }}-build-
+#          ${{ runner.os }}-
+#
+#    - name: Install Node dependencies
+#      run: npm install
+#
+#    - name: Build frontend assets
+#      run: npm run prod
 
     - name: Output debug information
       run: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -16,6 +16,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '14'
+
     - name: Validate composer.json and composer.lock
       run: composer validate
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -13,9 +13,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-#    - uses: actions/setup-node@v2
-#      with:
-#        node-version: '14'
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
 
     - name: Validate composer.json and composer.lock
       run: composer validate
@@ -38,25 +38,25 @@ jobs:
 
     - name: Install composer dependencies
       run: composer install
-#
-#    - name: Cache node modules
-#      uses: actions/cache@v3
-#      env:
-#        cache-name: cache-node-modules
-#      with:
-#        # npm cache files are stored in `~/.npm` on Linux/macOS
-#        path: ~/.npm
-#        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-#        restore-keys: |
-#          ${{ runner.os }}-build-${{ env.cache-name }}-
-#          ${{ runner.os }}-build-
-#          ${{ runner.os }}-
-#
-#    - name: Install Node dependencies
-#      run: npm install
-#
-#    - name: Build frontend assets
-#      run: npm run prod
+
+    - name: Cache node modules
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-node-modules
+      with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
+        path: ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: Install Node dependencies
+      run: npm install
+
+    - name: Build frontend assets
+      run: npm run prod
 
     - name: Output debug information
       run: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -69,12 +69,12 @@ jobs:
     - name: Create docs redirect
       run: echo '<meta http-equiv="refresh" content="0;url=/docs/1.x" />' > docs/docs/index.html
 
-    - name: Upload site artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: site
-        path: docs
+    - name: Move site from docs to _site
+      run: mv docs _site
 
+    - name: Package the static site
+      run: zip -r site.zip _site
+    
 
   comment-on-pull-request:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -75,31 +75,6 @@ jobs:
         name: site
         path: docs
 
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download the artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: "site"
-          path: docs
-      
-      - name: Upload files to GitHub Pages
-        uses: cpina/github-action-push-to-another-repository@v1.4.2
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-        with:
-          source-directory: "docs"
-          destination-github-username: "hydephp"
-          destination-repository-name: "previews"
-          target-branch: master
-          target-directory: "docs/hydephp-com/${{ github.event.pull_request.number }}"
-
-      - name: Output the URL
-        run: echo "https://ci.hydephp.com/previews/website/${{ github.event.pull_request.number }}"
-
 
   comment-on-pull-request:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master, upcoming ]
 
 jobs:
-  build:
+  build-and-deploy-preview:
     runs-on: ubuntu-latest
     environment:
       name: pull-request-preview

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -113,5 +113,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'A [live preview](https://ci.hydephp.com/previews/website/${{ github.event.pull_request.number }}) is being deployed!<br><br>Please note that it may take a few seconds for GitHub Pages to build and deploy. The preview will be removed at midnight UTC.'
+              body: 'A [live preview](https://ci.hydephp.com/previews/website/${{ github.event.pull_request.number }}) is being deployed!<br><br>Please note that it may take a few seconds the site to be available. Old previews are removed routinely.'
             })

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -75,6 +75,28 @@ jobs:
     - name: Package the static site
       run: zip -r site.zip _site
 
+    - name: Sign the artifact
+      run: |
+        echo '${{ secrets.CI_PREVIEW_SIGNING_RSA_PRIVATE_KEY }}' > private.pem
+        openssl dgst -sha256 -sign private.pem -out signature.bin site.zip
+        unlink private.pem
+
+    - name: Upload the artifact
+      run: |
+        repository="website"
+        bearerToken="${{ secrets.CI_SERVER_TOKEN }}"
+        pullRequest="${{ github.event.pull_request.number }}"
+        signature="$(openssl base64 -in signature.bin)"
+        artifact="site.zip"
+        
+        curl -X POST --fail-with-body \
+          -H "Content-Type: multipart/form-data" \
+          -H "Authorization: Bearer $bearerToken" \
+          -F "repository=$repository" \
+          -F "pullRequest=$pullRequest" \
+          -F "artifact=@$artifact" \
+          -F "signature=$signature" \
+          https://ci.hydephp.com/api/deployment-previews
 
   comment-on-pull-request:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -36,6 +36,10 @@ jobs:
         echo "TORCHLIGHT_TOKEN=${{ secrets.TORCHLIGHT_TOKEN }}" >> .env
         echo "ROBOTS_NOINDEX=true" >> .env
 
+    - name: Update config
+      run: |
+        echo output_directory: _site > hyde.yml
+
     - name: Install composer dependencies
       run: composer install
 
@@ -67,10 +71,7 @@ jobs:
       run: php hyde build --pretty-urls --no-interaction
 
     - name: Create docs redirect
-      run: echo '<meta http-equiv="refresh" content="0;url=/docs/1.x" />' > docs/docs/index.html
-
-    - name: Move site from docs to _site
-      run: mv docs _site
+      run: echo '<meta http-equiv="refresh" content="0;url=/docs/1.x" />' > _site/docs/index.html
 
     - name: Package the static site
       run: zip -r site.zip _site

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment:
+      name: pull-request-preview
+      url: https://ci.hydephp.com/previews/website/${{ github.event.pull_request.number }}
+
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v2
@@ -73,9 +77,6 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    environment:
-      name: pull-request-preview
-      url: https://ci.hydephp.com/previews/website/${{ github.event.pull_request.number }}
 
     steps:
       - name: Download the artifact

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         echo 'SITE_NAME="HydePHP.com PR Preview"' > .env
         echo "SITE_URL=https://ci.hydephp.com/previews/website/${{ github.event.pull_request.number }}" >> .env
-        # echo "TORCHLIGHT_TOKEN=${{ secrets.TORCHLIGHT_TOKEN }}" >> .env
+        echo "TORCHLIGHT_TOKEN=${{ secrets.TORCHLIGHT_TOKEN }}" >> .env
         echo "ROBOTS_NOINDEX=true" >> .env
 
     - name: Install composer dependencies


### PR DESCRIPTION
Moves to a custom deployment server which is much faster than GitHub Pages. Deployments are pretty much instant after the site build, so we can now get a preview live in under a minute instead of 2-3 minutes. Most of the build time now depends on NPM modules and the Torchlight API latency.

See https://github.com/hydephp/develop/pull/1543

