### PR TITLE
Turn off Torchlight line numbers globally

### DIFF
--- a/config/torchlight.php
+++ b/config/torchlight.php
@@ -74,7 +74,7 @@ return [
     // https://torchlight.dev/docs/options
     'options' => [
         // Turn line numbers on or off globally.
-        // 'lineNumbers' => false,
+        'lineNumbers' => false,
 
         // Control the `style` attribute applied to line numbers.
         // 'lineNumbersStyle' => '',


### PR DESCRIPTION
Most of our examples are short and this offers no value then. Better to opt in by adding this when needed:

```php
// torchlight! {"lineNumbers": true}
```